### PR TITLE
Create learning reinforcement practice files

### DIFF
--- a/json_practice.py
+++ b/json_practice.py
@@ -1,0 +1,89 @@
+import json
+from typing import Any, Dict, List
+
+
+def load_people_from_string(people_json: str) -> Dict[str, Any]:
+	"""Parse a JSON string and return a Python dict.
+
+	Expected top-level shape: {"people": [ {"name": str, "phone": str, "emails": [str, ...], "has_license": bool}, ... ]}
+	"""
+	# TODO: implement using json.loads
+	raise NotImplementedError
+
+
+def remove_key_from_people(data: Dict[str, Any], key_to_remove: str) -> Dict[str, Any]:
+	"""Return a new dict where each person dict no longer contains key_to_remove.
+
+	Do not mutate the input dict; return a deep-copied/constructed result.
+	"""
+	# TODO: implement without mutating input
+	raise NotImplementedError
+
+
+def people_to_sorted_json(data: Dict[str, Any]) -> str:
+	"""Return a JSON string with sorted keys and 2-space indentation.
+
+	Use json.dumps with indent=2 and sort_keys=True.
+	"""
+	# TODO: implement dumps formatting
+	raise NotImplementedError
+
+
+def get_people_without_license(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+	"""Return people whose has_license is False."""
+	# TODO: filter by has_license flag
+	raise NotImplementedError
+
+
+def extract_emails(data: Dict[str, Any]) -> List[str]:
+	"""Flatten and return all email addresses from the people list (preserve order)."""
+	# TODO: gather emails from each person in order
+	raise NotImplementedError
+
+
+def save_json_to_file(data: Dict[str, Any], path: str) -> None:
+	"""Write dict to a file as JSON (UTF-8), sorted keys and pretty-printed."""
+	# TODO: open(path, 'w', encoding='utf-8') and json.dump(...)
+	raise NotImplementedError
+
+
+def load_json_from_file(path: str) -> Dict[str, Any]:
+	"""Load dict from a JSON file (UTF-8)."""
+	# TODO: open(path, 'r', encoding='utf-8') and json.load(...)
+	raise NotImplementedError
+
+
+EXAMPLE_PEOPLE_JSON = (
+	"""
+	{
+	  "people": [
+	    {
+	      "name": "John Smith",
+	      "phone": "615-555-7164",
+	      "emails": ["john.doe@example.com", "john@doe.com"],
+	      "has_license": false
+	    },
+	    {
+	      "name": "Jane Doe",
+	      "phone": "615-555-7165",
+	      "emails": ["jane.doe@example.com", "jane@doe.com"],
+	      "has_license": true
+	    }
+	  ]
+	}
+	"""
+).strip()
+
+
+ADDENDUM = (
+	"""
+	Essential JSON/Python skills not to miss:
+	- json.loads vs json.load: loads parses a string; load reads from a file-like object.
+	- json.dumps vs json.dump: dumps returns a string; dump writes to a file-like object.
+	- Booleans are lowercase in JSON (true/false) but capitalized in Python (True/False). The json module maps them automatically.
+	- Ensure files are opened with explicit encoding="utf-8" for portability.
+	- Avoid mutating inputs in helper functions unless required; prefer returning new objects.
+	- Use indent and sort_keys for deterministic output when testing.
+	- When reading unknown JSON, validate shape defensively: use dict.get with defaults or try/except KeyError.
+	"""
+).strip()

--- a/tests/test_json_practice.py
+++ b/tests/test_json_practice.py
@@ -1,0 +1,85 @@
+import os
+import json
+import tempfile
+import unittest
+
+from json_practice import (
+	EXAMPLE_PEOPLE_JSON,
+	load_people_from_string,
+	remove_key_from_people,
+	people_to_sorted_json,
+	get_people_without_license,
+	extract_emails,
+	save_json_to_file,
+	load_json_from_file,
+)
+
+
+class TestJsonPractice(unittest.TestCase):
+	def setUp(self):
+		self.data = {
+			"people": [
+				{
+					"name": "John Smith",
+					"phone": "615-555-7164",
+					"emails": ["john.doe@example.com", "john@doe.com"],
+					"has_license": False,
+				},
+				{
+					"name": "Jane Doe",
+					"phone": "615-555-7165",
+					"emails": ["jane.doe@example.com", "jane@doe.com"],
+					"has_license": True,
+				},
+			]
+		}
+
+	def test_load_people_from_string(self):
+		parsed = load_people_from_string(EXAMPLE_PEOPLE_JSON)
+		self.assertIsInstance(parsed, dict)
+		self.assertIn("people", parsed)
+		self.assertEqual(len(parsed["people"]), 2)
+		self.assertIs(parsed["people"][0]["has_license"], False)
+		self.assertIs(parsed["people"][1]["has_license"], True)
+
+	def test_remove_key_from_people(self):
+		result = remove_key_from_people(self.data, "phone")
+		self.assertIsNot(result, self.data)
+		self.assertIn("people", result)
+		for original, updated in zip(self.data["people"], result["people"]):
+			self.assertIn("phone", original)
+			self.assertNotIn("phone", updated)
+
+	def test_people_to_sorted_json(self):
+		result_json = people_to_sorted_json(self.data)
+		loaded = json.loads(result_json)
+		self.assertEqual(loaded, self.data)
+		self.assertIn("\n  \"people\": ", result_json)
+
+	def test_get_people_without_license(self):
+		non_licensed = get_people_without_license(self.data)
+		self.assertEqual(len(non_licensed), 1)
+		self.assertEqual(non_licensed[0]["name"], "John Smith")
+
+	def test_extract_emails(self):
+		emails = extract_emails(self.data)
+		self.assertEqual(
+			emails,
+			[
+				"john.doe@example.com",
+				"john@doe.com",
+				"jane.doe@example.com",
+				"jane@doe.com",
+			],
+		)
+
+	def test_save_and_load_json_file(self):
+		with tempfile.TemporaryDirectory() as tmp:
+			path = os.path.join(tmp, "people.json")
+			save_json_to_file(self.data, path)
+			loaded = load_json_from_file(path)
+			self.assertEqual(loaded, self.data)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Add JSON practice file and its test suite to reinforce learning.

The user requested practice files with a standard naming convention and a way to test their implementations. This PR introduces `json_practice.py` with exercises and an addendum of essential skills, along with `tests/test_json_practice.py` to validate solutions.

---
<a href="https://cursor.com/background-agent?bcId=bc-66f30318-a977-4d5e-83f9-230ebb0ef2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66f30318-a977-4d5e-83f9-230ebb0ef2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

